### PR TITLE
[CAPPS-98] adding new data attribute for linking back to login page in registration

### DIFF
--- a/views/demo/register.njk
+++ b/views/demo/register.njk
@@ -2,6 +2,7 @@
 
 {% block content %}
     <div class="mariana-customer-register-binding"
+        data-mariana-login-redirect-url="{{baseUrl}}/login/"
         data-mariana-redirect-url="{{baseUrl}}/account/"
         data-mariana-terms-of-service-url="{{baseUrl}}/terms-of-service/"></div>
 {% endblock %}


### PR DESCRIPTION
This adds a new data-attribute for linking back to login page in registration for this ticket: https://marianatek.atlassian.net/browse/CAPPS-98